### PR TITLE
CIR-2732-Test pack uplifted from Scala 2.13.16 to Scala 3.3.7 Updated the dependencies performance-test-runner version to 6.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "outcome-auditing-api-perf-tests",
     version := "0.1.0-SNAPSHOT",
-    scalaVersion := "2.13.16",
+    scalaVersion := "3.3.7",
     //implicitConversions & postfixOps are Gatling recommended -language settings
     scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,6 @@ import sbt._
 object Dependencies {
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "performance-test-runner" % "6.2.0"
+    "uk.gov.hmrc" %% "performance-test-runner" % "6.3.0"
   ).map(_ % Test)
 }


### PR DESCRIPTION
Test pack uplifted from Scala 2.13.16 to Scala 3.3.7 Updated the dependencies performance-test-runner version to 6.3.0